### PR TITLE
Update deprecated React Native lifecycle methods.

### DIFF
--- a/ImageItem.js
+++ b/ImageItem.js
@@ -28,14 +28,21 @@ const styles = StyleSheet.create({
 });
 
 class ImageItem extends Component {
-  componentWillMount() {
+  state = {
+    imageSize: null,
+    isMounting: true
+  }
+
+  componentDidMount() {
     let { width } = Dimensions.get('window');
     const { imageMargin, imagesPerRow, containerWidth } = this.props;
 
     if (typeof containerWidth !== 'undefined') {
       width = containerWidth;
     }
-    this.imageSize = (width - (imagesPerRow + 1) * imageMargin) / imagesPerRow;
+    const imageSize = (width - (imagesPerRow + 1) * imageMargin) / imagesPerRow;
+
+    this.setState({ imageSize, isMounting: false });
   }
 
   handleClick(item) {
@@ -43,6 +50,8 @@ class ImageItem extends Component {
   }
 
   render() {
+    if ( this.state.isMounting ) return null;
+
     const {
       item, selected, selectedMarker, imageMargin,
     } = this.props;
@@ -66,7 +75,7 @@ class ImageItem extends Component {
       >
         <Image
           source={{ uri: image.uri }}
-          style={{ height: this.imageSize, width: this.imageSize }}
+          style={{ height: this.state.imageSize, width: this.state.imageSize }}
         />
         {videoMarker}
         {(selected) ? marker : null}

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ class CameraRollPicker extends Component {
 
     this.state = {
       images: [],
+      isMounting: true,
       selected: this.props.selected,
       lastCursor: null,
       initialLoading: true,
@@ -71,18 +72,22 @@ class CameraRollPicker extends Component {
     this.renderImage = this.renderImage.bind(this);
   }
 
-  async componentWillMount() {
+  async componentDidMount() {
     if (Platform.OS === "android" && !(await this.hasAndroidPermission())) {
       return;
     }
 
     this.fetch();
+
+    this.setState({ isMounting: false });
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      selected: nextProps.selected,
-    });
+  componentDidUpdate(prevProps) {
+    if (JSON.stringify(prevProps.selected) !== JSON.stringify( this.props.selected)) { // Only update `this.state.selected` if `this.props.selected` changes. Without this `if`, it causes an infinite loop.
+      this.setState({
+        selected: this.props.selected,
+      });
+    }
   }
 
   // Ensure we have the correct permissions read external storage on Android (required for Android 10+).
@@ -235,6 +240,8 @@ class CameraRollPicker extends Component {
   }
 
   render() {
+    if (this.state.isMounting ) return null;
+
     const {
       initialNumToRender,
       imageMargin,


### PR DESCRIPTION
Change `componentWillMount` to `componentDidMount` and `componentWillReceiveProps` to `componentDidUpdate`. These changes removed the React Native warnings about deprecated lifecycle methods.