### PR TITLE
Manually sort images/videos by date.

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,11 @@ class CameraRollPicker extends Component {
     fetchParams.include = [ "playableDuration" ]; // Include playableDuration by default as this will remove thumbnails that don't exist. e.g. /storage/emulated/0/ddmsrec.mp4 from screen recording.
 
     CameraRoll.getPhotos(fetchParams)
-      .then(data => this.appendImages(data), e => console.log(e));
+      .then(data => {
+        data.edges.sort((a, b) => b.node.timestamp - a.node.timestamp); // We have to sort the images by `timestamp` because `getPhotos` sometimes doesn't. See this issue: https://github.com/react-native-cameraroll/react-native-cameraroll/issues/45.
+        this.appendImages(data);
+      })
+      .catch(error => console.error(error));
   }
 
   selectImage(image) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/jeanpan/react-native-camera-roll-picker/issues"
   },
   "dependencies": {
-    "@react-native-community/cameraroll": "^4.0.1",
+    "@react-native-community/cameraroll": "^4.0.4",
     "prop-types": "^15.6.0"
   },
   "homepage": "https://github.com/jeanpan/react-native-camera-roll-picker#readme",


### PR DESCRIPTION
The images/videos retrieved were not consistently sorted by date, so thanks to [this comment](https://github.com/react-native-cameraroll/react-native-cameraroll/issues/45#issuecomment-485872830), we now sort the images/videos by `timestamp` after retrieving them using `CameraRoll.getPhotos`.

Also, I noticed that this still had issues sometimes, so I dug deeper, and noticed that the `timestamp` for some images/videos was set to `0`. I remembered seeing on the [releases page for `react-native-cameraroll`](https://github.com/react-native-cameraroll/react-native-cameraroll/releases) that this issue was fixed in `4.0.3`, so I upgraded the package to the latest release (4.0.4), and that fixed the issue.