### PR TITLE
Add optional file names to the top of each thumbnail image.

### DIFF
--- a/ImageItem.js
+++ b/ImageItem.js
@@ -3,7 +3,9 @@ import {
   Image,
   StyleSheet,
   Dimensions,
+  Text,
   TouchableOpacity,
+  View,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
@@ -66,6 +68,7 @@ class ImageItem extends Component {
     />);
 
     const { image } = item.node;
+    const fileName  = image.uri.split( "/" ).pop();
 
     return (
       <TouchableOpacity
@@ -77,6 +80,13 @@ class ImageItem extends Component {
           source={{ uri: image.uri }}
           style={{ height: this.state.imageSize, width: this.state.imageSize }}
         />
+        { this.props.showsFileName &&
+          <View style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0, justifyContent: "flex-start", alignItems: "center", padding: 5 }}>
+            <View style={{ backgroundColor: "rgba( 255, 255, 255, 0.5 )", borderRadius: 10, paddingHorizontal: 8, paddingVertical: 3 }}>
+              <Text style={{ fontSize: 12 }}>{fileName}</Text>
+            </View>
+          </View>
+        }
         {videoMarker}
         {(selected) ? marker : null}
       </TouchableOpacity>
@@ -96,6 +106,7 @@ ImageItem.propTypes = {
   imageMargin: PropTypes.number,
   imagesPerRow: PropTypes.number,
   onClick: PropTypes.func,
+  showsFileName: PropTypes.bool.isRequired,
 };
 
 export default ImageItem;

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import CameraRollPicker from 'react-native-camera-roll-picker';
 - `emptyText`: Text to display instead of a list when there are no photos found. (Default: 'No photos.')
 - `emptyTextStyle`: Styles to apply to the `emptyText`. (Default: `textAlign: 'center'`)
 - `loader`: Loader component node. (Default: `<ActivityIndicator />`)
+- `showsFileNames`: Boolean to show image/video file name at the top of each image. (Default: `false`)
 
 ## Run Example
 ```

--- a/Row.js
+++ b/Row.js
@@ -40,6 +40,7 @@ class Row extends PureComponent {
         imagesPerRow={imagesPerRow}
         containerWidth={containerWidth}
         onClick={this.props.selectImage}
+        showsFileName={this.props.showsFileNames}
       />
     );
   }
@@ -64,6 +65,7 @@ Row.propTypes = {
   rowData: PropTypes.array.isRequired,
   isSelected: PropTypes.array.isRequired,
   selectImage: PropTypes.func.isRequired,
+  showsFileNames: PropTypes.bool.isRequired,
 };
 
 export default Row;

--- a/index.js
+++ b/index.js
@@ -214,6 +214,7 @@ class CameraRollPicker extends Component {
         imagesPerRow={imagesPerRow}
         containerWidth={containerWidth}
         onClick={this.selectImage}
+        showsFileName={this.props.showsFileNames}
       />
     );
   }
@@ -232,6 +233,7 @@ class CameraRollPicker extends Component {
       containerWidth={this.props.containerWidth}
       imageMargin={this.props.imageMargin}
       selectedMarker={this.props.selectedMarker}
+      showsFileNames={this.props.showsFileNames}
     />);
   }
 
@@ -315,6 +317,7 @@ CameraRollPicker.propTypes = {
   emptyText: PropTypes.string,
   emptyTextStyle: Text.propTypes.style,
   loader: PropTypes.node,
+  showsFileNames: PropTypes.bool,
 };
 
 CameraRollPicker.defaultProps = {
@@ -332,6 +335,7 @@ CameraRollPicker.defaultProps = {
     console.log(selectedImages);
   },
   emptyText: 'No photos.',
+  showsFileNames: false,
 };
 
 export default CameraRollPicker;


### PR DESCRIPTION
Added a prop called `showsFileNames` which defaults to `false`. When true, each thumbnail will display the file name at the top of the image.

![Gallery With File Names](https://user-images.githubusercontent.com/36489467/126369834-2d3fd8d7-12d3-41a6-8724-62cb3df2d5ce.png)

Updated `README.md` with new prop.